### PR TITLE
ImageService 단위 테스트 구현

### DIFF
--- a/SwinjectReactorKitExample.xcodeproj/project.pbxproj
+++ b/SwinjectReactorKitExample.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		442755C8083629242D5CD233 /* Pods_SwinjectReactorKitExample_SwinjectReactorKitExampleUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB533760722B25B1C5FAB63D /* Pods_SwinjectReactorKitExample_SwinjectReactorKitExampleUITests.framework */; };
 		4DF17FC3D0E97E996DD412E8 /* Pods_SwinjectReactorKitExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB97D9A7117DF06B1E4E8846 /* Pods_SwinjectReactorKitExample.framework */; };
 		8B7388F7B7A3919E28F190F4 /* Pods_SwinjectReactorKitExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 10E66A81AE6C7E18DB1A44B5 /* Pods_SwinjectReactorKitExampleTests.framework */; };
+		D49CCD182678621C001B7F2A /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49CCD172678621C001B7F2A /* MockURLSession.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +80,7 @@
 		40EC0360267834C400589C9D /* Joke.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Joke.swift; sourceTree = "<group>"; };
 		5D4C3BDE8DCED8D44BC70862 /* Pods-SwinjectReactorKitExample-SwinjectReactorKitExampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwinjectReactorKitExample-SwinjectReactorKitExampleUITests.debug.xcconfig"; path = "Target Support Files/Pods-SwinjectReactorKitExample-SwinjectReactorKitExampleUITests/Pods-SwinjectReactorKitExample-SwinjectReactorKitExampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		A4ED93C563C3F5F6B76C65B6 /* Pods-SwinjectReactorKitExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwinjectReactorKitExampleTests.release.xcconfig"; path = "Target Support Files/Pods-SwinjectReactorKitExampleTests/Pods-SwinjectReactorKitExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		D49CCD172678621C001B7F2A /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		DB97D9A7117DF06B1E4E8846 /* Pods_SwinjectReactorKitExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwinjectReactorKitExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB533760722B25B1C5FAB63D /* Pods_SwinjectReactorKitExample_SwinjectReactorKitExampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwinjectReactorKitExample_SwinjectReactorKitExampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -164,6 +166,7 @@
 		405C9DA726579CFB00C33809 /* SwinjectReactorKitExampleTests */ = {
 			isa = PBXGroup;
 			children = (
+				D49CCD16267861E8001B7F2A /* Mock */,
 				40EC035B26774B3C00589C9D /* ImageServiceTest.swift */,
 				405C9DA826579CFB00C33809 /* SwinjectReactorKitExampleTests.swift */,
 				405C9DAA26579CFB00C33809 /* Info.plist */,
@@ -300,6 +303,14 @@
 				A4ED93C563C3F5F6B76C65B6 /* Pods-SwinjectReactorKitExampleTests.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		D49CCD16267861E8001B7F2A /* Mock */ = {
+			isa = PBXGroup;
+			children = (
+				D49CCD172678621C001B7F2A /* MockURLSession.swift */,
+			);
+			path = Mock;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -577,6 +588,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D49CCD182678621C001B7F2A /* MockURLSession.swift in Sources */,
 				405C9DA926579CFB00C33809 /* SwinjectReactorKitExampleTests.swift in Sources */,
 				40EC035C26774B3C00589C9D /* ImageServiceTest.swift in Sources */,
 			);

--- a/SwinjectReactorKitExample.xcodeproj/xcshareddata/xcschemes/SwinjectReactorKitExample.xcscheme
+++ b/SwinjectReactorKitExample.xcodeproj/xcshareddata/xcschemes/SwinjectReactorKitExample.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/SwinjectReactorKitExample/Sources/BusinessLayer/Service/ImageService.swift
+++ b/SwinjectReactorKitExample/Sources/BusinessLayer/Service/ImageService.swift
@@ -46,43 +46,36 @@ final class ImageService: ImageServiceType {
         let task = self.urlSession.dataTask(with: request) { data, response, error in
             guard error == nil else { 
                 print("ImageDownloadError.networkError", error!.localizedDescription)
-//                single(.error(error!))
                 completion(.failure(ImageDownloadError.networkError))
-                
                 return
             }
             
             guard let response = response as? HTTPURLResponse else {
                 print("ImageDownloadError.responseError")
-//                single(.error(ImageDownloadError.responseError))
                 completion(.failure(ImageDownloadError.responseError))
                 return
             }
             
             guard 200..<300 ~= response.statusCode else {
                 print("ImageDownloadError.statusError")
-//                single(.error(ImageDownloadError.statusError))
                 completion(.failure(ImageDownloadError.statusError))
                 return
             }
             
             guard data != nil else {
                 print("ImageDownloadError.dataError")
-//                single(.error(ImageDownloadError.dataError))
                 completion(.failure(ImageDownloadError.dataError))
                 return
             }
             
             print("data received")
-            
-//            single(.success(data!))
             completion(.success(data!))
             
             CachStorage.shared.cachedImage.setObject(data! as NSData, forKey: url as NSURL)
         }
         
         task.resume()
-        
+
         self.task = task
     }
     

--- a/SwinjectReactorKitExample/Sources/DataLayer/Network/NetworkAPI.swift
+++ b/SwinjectReactorKitExample/Sources/DataLayer/Network/NetworkAPI.swift
@@ -13,7 +13,7 @@ enum NetworkAPI {
 }
 
 extension NetworkAPI {
-    static var baseURLForTest: URL = URL(string: "https://api.github.com")!
+    static var baseURLForTest: URL = URL(string: "https://avatars.githubusercontent.com/u/57659933?v=4")!
     
     static let sampleDataForTest: Data = Data(
             """

--- a/SwinjectReactorKitExampleTests/Mock/MockURLSession.swift
+++ b/SwinjectReactorKitExampleTests/Mock/MockURLSession.swift
@@ -1,0 +1,61 @@
+//
+//  MockURLSession.swift
+//  SwinjectReactorKitExampleTests
+//
+//  Created by 홍경표 on 2021/06/15.
+//
+
+@testable import SwinjectReactorKitExample
+import Foundation
+
+class MockURLSessionDataTask: URLSessionDataTask {
+    override init() { }
+    var resumeDidCall: () -> Void = { }
+    
+    override func resume() {
+        resumeDidCall()
+    }
+    
+    override func cancel() {
+        print("MockURLSessionDataTask Cancelled!")
+    }
+}
+
+class MockURLSession: URLSessionType {
+    
+    var makeRequestFail = false
+    init(makeRequestFail: Bool = false) {
+        self.makeRequestFail = makeRequestFail
+    }
+    
+    var sessionDataTask: MockURLSessionDataTask?
+    
+    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        
+        let successResponse = HTTPURLResponse(
+            url: NetworkAPI.baseURLForTest,
+            statusCode: 200,
+            httpVersion: "2",
+            headerFields: nil
+        )
+        
+        let failureResponse = HTTPURLResponse(
+            url: NetworkAPI.baseURLForTest,
+            statusCode: 410,
+            httpVersion: "2",
+            headerFields: nil
+        )
+        
+        let sessionDataTask = MockURLSessionDataTask()
+        
+        sessionDataTask.resumeDidCall = {
+            if self.makeRequestFail {
+                completionHandler(nil, failureResponse, nil)
+            } else {
+                completionHandler(NetworkAPI.sampleDataForTest, successResponse, nil)
+            }
+        }
+        self.sessionDataTask = sessionDataTask
+        return sessionDataTask
+    }
+}


### PR DESCRIPTION
### Done 
- `MockURLSession`, `MockURLSessionDataTask` 구현
- `ImageService` 생성, mock urlSession 주입 후 `fetchData` 테스트
- `ImageService` 생성, mock urlSession 주입 후 `fetchImage` 테스트

### Todo
- 나중에 시간이 된다면 urlSession에서 rawData를 가져오는 `fetchData` 부분을 `Repository` 계층으로 분리,,